### PR TITLE
Added functionality in the pure hot plus cool link

### DIFF
--- a/libpurecoollink/const.py
+++ b/libpurecoollink/const.py
@@ -1,6 +1,11 @@
 """Dyson Pure Cool Link constants."""
 
 from enum import Enum
+from .exceptions import DysonInvalidTargetTemperatureException as DITTE
+
+DYSON_PURE_COOL_LINK_TOUR = "475"
+DYSON_PURE_COOL_LINK_DESK = "469"
+DYSON_PURE_HOT_COOL_LINK_TOUR = "455"
 
 
 class FanMode(Enum):
@@ -65,20 +70,38 @@ class StandbyMonitoring(Enum):
 
 class FocusMode(Enum):
     """Fan operates in a focused stream or wide spread."""
+
     FOCUS_OFF = "OFF"
     FOCUS_ON = "ON"
 
 
 class HeatMode(Enum):
     """Heat mode for the fan."""
+
     HEAT_OFF = "OFF"
     HEAT_ON = "HEAT"
 
 
-class HeatTarget(Enum):
+class HeatTarget:
     """Heat Target for fan. Note dyson uses kelvin as the temperature unit."""
-    def CELSIUS(temperature):
-        """Convert the given int to string constant. Value temperature is 1 to 37 celius"""
+
+    @staticmethod
+    def celsius(temperature):
+        """Convert the given int celsius temperature to string in Kelvin.
+
+        :param temperature temperature in celsius between 1 to 37 inclusive.
+        """
         if temperature < 1 or temperature > 37:
-            raise "Invalid temperature. It must be between 1 to 37 inclusive."
-        return str((int(temperature) + 273) * 10) # target temperature in kelvin, padd with zero
+            raise DITTE(DITTE.CELSIUS, temperature)
+        return str((int(temperature) + 273) * 10)
+
+    @staticmethod
+    def fahrenheit(temperature):
+        """Convert the given int fahrenheit temperature to string in Kelvin.
+
+        :param temperature temperature in fahrenheit between 34 to 98
+                            inclusive.
+        """
+        if temperature < 34 or temperature > 98:
+            raise DITTE(DITTE.FAHRENHEIT, temperature)
+        return str(int((int(temperature) + 459.67) * 5/9) * 10)

--- a/libpurecoollink/const.py
+++ b/libpurecoollink/const.py
@@ -74,11 +74,13 @@ class FocusMode(Enum):
     FOCUS_OFF = "OFF"
     FOCUS_ON = "ON"
 
+
 class TiltState(Enum):
     """Indicates if device is tilted."""
 
     TILT_TRUE = "TILT"
     TILT_FALSE = "OK"
+
 
 class HeatMode(Enum):
     """Heat mode for the fan."""
@@ -86,11 +88,13 @@ class HeatMode(Enum):
     HEAT_OFF = "OFF"
     HEAT_ON = "HEAT"
 
+
 class HeatState(Enum):
     """Heating State."""
 
     HEAT_STATE_OFF = "OFF"
     HEAT_STATE_ON = "HEAT"
+
 
 class HeatTarget:
     """Heat Target for fan. Note dyson uses kelvin as the temperature unit."""

--- a/libpurecoollink/const.py
+++ b/libpurecoollink/const.py
@@ -74,6 +74,11 @@ class FocusMode(Enum):
     FOCUS_OFF = "OFF"
     FOCUS_ON = "ON"
 
+class TiltState(Enum):
+    """Indicates if device is tilted."""
+
+    TILT_TRUE = "TILT"
+    TILT_FALSE = "OK"
 
 class HeatMode(Enum):
     """Heat mode for the fan."""
@@ -81,6 +86,11 @@ class HeatMode(Enum):
     HEAT_OFF = "OFF"
     HEAT_ON = "HEAT"
 
+class HeatState(Enum):
+    """Heating State."""
+
+    HEAT_STATE_OFF = "OFF"
+    HEAT_STATE_ON = "HEAT"
 
 class HeatTarget:
     """Heat Target for fan. Note dyson uses kelvin as the temperature unit."""

--- a/libpurecoollink/const.py
+++ b/libpurecoollink/const.py
@@ -61,3 +61,24 @@ class StandbyMonitoring(Enum):
 
     STANDBY_MONITORING_ON = "ON"
     STANDBY_MONITORING_OFF = "OFF"
+
+
+class FocusMode(Enum):
+    """Fan operates in a focused stream or wide spread."""
+    FOCUS_OFF = "OFF"
+    FOCUS_ON = "ON"
+
+
+class HeatMode(Enum):
+    """Heat mode for the fan."""
+    HEAT_OFF = "OFF"
+    HEAT_ON = "HEAT"
+
+
+class HeatTarget(Enum):
+    """Heat Target for fan. Note dyson uses kelvin as the temperature unit."""
+    def CELSIUS(temperature):
+        """Convert the given int to string constant. Value temperature is 1 to 37 celius"""
+        if temperature < 1 or temperature > 37:
+            raise "Invalid temperature. It must be between 1 to 37 inclusive."
+        return str((int(temperature) + 273) * 10) # target temperature in kelvin, padd with zero

--- a/libpurecoollink/dyson.py
+++ b/libpurecoollink/dyson.py
@@ -681,7 +681,7 @@ class DysonState:
 
     @property
     def tilt(self):
-        """Is it tilting???."""
+        """Indicates if the device is tilted."""
         return self._tilt
 
     @property
@@ -701,7 +701,7 @@ class DysonState:
 
     @property
     def heat_state(self):
-        """Heat state."""
+        """Indicates if heating is actually on."""
         return self._heat_state
 
     def __repr__(self):

--- a/libpurecoollink/dyson.py
+++ b/libpurecoollink/dyson.py
@@ -681,7 +681,7 @@ class DysonState:
 
     @property
     def tilt(self):
-        """Indicates if the device is tilted."""
+        """Return tilt status."""
         return self._tilt
 
     @property
@@ -701,7 +701,7 @@ class DysonState:
 
     @property
     def heat_state(self):
-        """Indicates if heating is actually on."""
+        """Return heat state."""
         return self._heat_state
 
     def __repr__(self):

--- a/libpurecoollink/exceptions.py
+++ b/libpurecoollink/exceptions.py
@@ -1,0 +1,37 @@
+"""Dyson exceptions."""
+
+
+class DysonInvalidTargetTemperatureException(Exception):
+    """Invalid target temperature Exception."""
+
+    CELSIUS = "Celsius"
+    FAHRENHEIT = "Fahrenheit"
+
+    def __init__(self, temperature_unit, current_value):
+        """Dyson invalid target temperature.
+
+        :param temperature_unit Celsius/Fahrenheit
+        :param current_value invalid value
+        """
+        super(DysonInvalidTargetTemperatureException, self).__init__()
+        self._temperature_unit = temperature_unit
+        self._current_value = current_value
+
+    @property
+    def temperature_unit(self):
+        """Temperature unit: Celsius or Fahrenheit."""
+        return self._temperature_unit
+
+    @property
+    def current_value(self):
+        """Return Current value."""
+        return self._current_value
+
+    def __repr__(self):
+        """Return a String representation."""
+        if self.temperature_unit == self.CELSIUS:
+            return "{0} is not a valid temperature target. It must be " \
+                   "between 1 to 37 inclusive.".format(self._current_value)
+        if self.temperature_unit == self.FAHRENHEIT:
+            return "{0} is not a valid temperature target. It must be " \
+                   "between 34 to 98 inclusive.".format(self._current_value)

--- a/libpurecoollink/utils.py
+++ b/libpurecoollink/utils.py
@@ -1,0 +1,22 @@
+"""Utilities for Dyson Pure Hot+Cool link devices."""
+
+from .const import DYSON_PURE_HOT_COOL_LINK_TOUR
+
+
+def support_heating(product_type):
+    """Return True if device_model support heating mode, else False.
+
+    :param product_type Dyson device model
+    """
+    if product_type in [DYSON_PURE_HOT_COOL_LINK_TOUR]:
+        return True
+    return False
+
+
+def printable_fields(fields):
+    """Return printable fields.
+
+    :param fields list of tuble with (label, vallue)
+    """
+    for field in fields:
+        yield field[0]+"="+field[1]

--- a/tests/data/state_hot.json
+++ b/tests/data/state_hot.json
@@ -16,11 +16,11 @@
     "ercd": "02C0",
     "nmod": "ON",
     "wacd": "NONE",
-    "tilt": "Value",
-    "ffoc": "spread",
-    "hmax": "295",
-    "hmod": "on",
-    "hsta": "heat"
+    "tilt": "OK",
+    "ffoc": "ON",
+    "hmax": "2950",
+    "hmod": "HEAT",
+    "hsta": "HEAT"
   },
   "scheduler": {
     "srsc": "cbd0",

--- a/tests/data/state_hot.json
+++ b/tests/data/state_hot.json
@@ -1,0 +1,30 @@
+{
+  "msg": "CURRENT-STATE",
+  "time": "2017-02-26T16:25:35.000Z",
+  "mode-reason": "LAPP",
+  "state-reason": "ENV",
+  "dial": "OFF",
+  "rssi": "-55",
+  "product-state": {
+    "fmod": "AUTO",
+    "fnst": "FAN",
+    "fnsp": "AUTO",
+    "qtar": "0004",
+    "oson": "OFF",
+    "rhtm": "ON",
+    "filf": "2087",
+    "ercd": "02C0",
+    "nmod": "ON",
+    "wacd": "NONE",
+    "tilt": "Value",
+    "ffoc": "spread",
+    "hmax": "295",
+    "hmod": "on",
+    "hsta": "heat"
+  },
+  "scheduler": {
+    "srsc": "cbd0",
+    "dstv": "0001",
+    "tzid": "0001"
+  }
+}

--- a/tests/test_libpurecoollink.py
+++ b/tests/test_libpurecoollink.py
@@ -712,13 +712,13 @@ class TestLibPureCoolLink(unittest.TestCase):
         self.assertEqual(dyson_state.heat_mode, HeatMode.HEAT_ON.value)
         self.assertEqual(dyson_state.heat_state, HeatState.HEAT_STATE_ON.value)
         self.assertEqual(dyson_state.tilt, TiltState.TILT_FALSE.value)
-        self.assertEqual(dyson_state.focus_mode, FocusMode.FOCUS_OFF.value)
+        self.assertEqual(dyson_state.focus_mode, FocusMode.FOCUS_ON.value)
         self.assertEqual(dyson_state.heat_target, '2950')
         self.assertEqual(dyson_state.__repr__(),
                          "DysonState(fan_mode=AUTO,fan_state=FAN,"
                          "night_mode=ON,speed=AUTO,oscillation=OFF,"
                          "filter_life=2087,quality_target=0004,"
-                         "standby_monitoring=ON,tilt=OK,focus_mode=OFF,"
+                         "standby_monitoring=ON,tilt=OK,focus_mode=ON,"
                          "heat_mode=HEAT,heat_target=2950,heat_state=HEAT)")
         self.assertEqual(dyson_state.quality_target,
                          QualityTarget.QUALITY_NORMAL.value)

--- a/tests/test_libpurecoollink.py
+++ b/tests/test_libpurecoollink.py
@@ -8,7 +8,10 @@ from libpurecoollink.dyson import DysonAccount, NetworkDevice, \
     DysonPureCoolLink, DysonState, DysonNotLoggedException, \
     DysonEnvironmentalSensorState
 from libpurecoollink.const import FanMode, NightMode, FanSpeed, Oscillation, \
-    FanState, QualityTarget, StandbyMonitoring as SM
+    FanState, QualityTarget, StandbyMonitoring as SM, \
+    DYSON_PURE_COOL_LINK_DESK as Desk, DYSON_PURE_HOT_COOL_LINK_TOUR as Hot, \
+    HeatMode, HeatTarget, FocusMode
+from libpurecoollink.exceptions import DysonInvalidTargetTemperatureException
 
 
 class MockResponse:
@@ -95,7 +98,7 @@ def _mocked_request_state(*args, **kwargs):
 
 
 def _mocked_send_command(*args, **kwargs):
-    assert args[0] == '475/device-id-1/command'
+    assert args[0] == '{0}/device-id-1/command'.format(Desk)
     payload = json.loads(args[1])
     if payload['msg'] == "STATE-SET":
         assert payload['time']
@@ -107,6 +110,27 @@ def _mocked_send_command(*args, **kwargs):
         assert payload['data']['fnsp'] == "0003"
         assert payload['data']['sltm'] == "STET"
         assert payload['data']['rhtm'] == "ON"
+        assert payload['mode-reason'] == "LAPP"
+        assert payload['msg'] == "STATE-SET"
+        assert args[2] == 1
+
+
+def _mocked_send_command_hot(*args, **kwargs):
+    assert args[0] == '{0}/device-id-1/command'.format(Hot)
+    payload = json.loads(args[1])
+    if payload['msg'] == "STATE-SET":
+        assert payload['time']
+        assert payload['data']['fmod'] == "FAN"
+        assert payload['data']['nmod'] == "OFF"
+        assert payload['data']['oson'] == "ON"
+        assert payload['data']['rstf'] == "STET"
+        assert payload['data']['qtar'] == "0004"
+        assert payload['data']['fnsp'] == "0003"
+        assert payload['data']['sltm'] == "STET"
+        assert payload['data']['rhtm'] == "ON"
+        assert payload['data']['hmod'] == "HEAT"
+        assert payload['data']['hmax'] == "2980"
+        assert payload['data']['ffoc'] == "ON"
         assert payload['mode-reason'] == "LAPP"
         assert payload['msg'] == "STATE-SET"
         assert args[2] == 1
@@ -463,12 +487,12 @@ class TestLibPureCoolLink(unittest.TestCase):
                                 "e1i0ZHakFH84DZuxsSQ4KTT2vbCm7uYeTORULKLKQ==",
             "AutoUpdate": True,
             "NewVersionAvailable": False,
-            "ProductType": "475"
+            "ProductType": Desk
         })
         network_device = NetworkDevice('device-1', 'host', 1111)
         device._add_network_device(network_device)
-        device._current_state = DysonState(open("tests/data/state.json", "r").
-                                           read())
+        device._current_state = DysonState(Desk, open("tests/data/state.json",
+                                                      "r").read())
         device.connection_callback(True)
         device.state_data_available()
         device.sensor_data_available()
@@ -484,8 +508,57 @@ class TestLibPureCoolLink(unittest.TestCase):
                                  )
         self.assertEqual(mocked_publish.call_count, 3)
         self.assertEqual(device.__repr__(),
-                         "DysonDevice(device-id-1,True,device-1,21.03.08,True"
-                         ",False,475,NetworkDevice(device-1,host,1111))")
+                         "DysonDevice(serial=device-id-1,active=True,"
+                         "name=device-1,version=21.03.08,auto_update=True,"
+                         "new_version_available=False,product_type=469,"
+                         "network_device=NetworkDevice(name=device-1,"
+                         "address=host,port=1111))")
+        device.disconnect()
+
+    @mock.patch('paho.mqtt.client.Client.publish',
+                side_effect=_mocked_send_command_hot)
+    @mock.patch('paho.mqtt.client.Client.connect')
+    def test_set_configuration_hot(self, mocked_connect, mocked_publish):
+        device = DysonPureCoolLink({
+            "Active": True,
+            "Serial": "device-id-1",
+            "Name": "device-1",
+            "ScaleUnit": "SU01",
+            "Version": "21.03.08",
+            "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuef86kQDQPefbQ6/70ZGysII1K"
+                                "e1i0ZHakFH84DZuxsSQ4KTT2vbCm7uYeTORULKLKQ==",
+            "AutoUpdate": True,
+            "NewVersionAvailable": False,
+            "ProductType": Hot
+        })
+        network_device = NetworkDevice('device-1', 'host', 1111)
+        device._add_network_device(network_device)
+        device._current_state = DysonState(Hot,
+                                           open("tests/data/state_hot.json",
+                                                "r").read())
+        device.connection_callback(True)
+        device.state_data_available()
+        device.sensor_data_available()
+        connected = device.connect(None)
+        self.assertTrue(connected)
+        self.assertEqual(mocked_connect.call_count, 1)
+        device.set_configuration(fan_mode=FanMode.FAN,
+                                 oscillation=Oscillation.OSCILLATION_ON,
+                                 fan_speed=FanSpeed.FAN_SPEED_3,
+                                 night_mode=NightMode.NIGHT_MODE_OFF,
+                                 quality_target=QualityTarget.QUALITY_NORMAL,
+                                 standby_monitoring=SM.STANDBY_MONITORING_ON,
+                                 heat_mode=HeatMode.HEAT_ON,
+                                 focus_mode=FocusMode.FOCUS_ON,
+                                 heat_target=HeatTarget.celsius(25)
+                                 )
+        self.assertEqual(mocked_publish.call_count, 3)
+        self.assertEqual(device.__repr__(),
+                         "DysonDevice(serial=device-id-1,active=True,"
+                         "name=device-1,version=21.03.08,auto_update=True,"
+                         "new_version_available=False,product_type=455,"
+                         "network_device=NetworkDevice(name=device-1,"
+                         "address=host,port=1111))")
         device.disconnect()
 
     @mock.patch('paho.mqtt.client.Client.publish',
@@ -506,8 +579,8 @@ class TestLibPureCoolLink(unittest.TestCase):
         })
         network_device = NetworkDevice('device-1', 'host', 1111)
         device._add_network_device(network_device)
-        device._current_state = DysonState(open("tests/data/state.json", "r").
-                                           read())
+        device._current_state = DysonState(Desk, open("tests/data/state.json",
+                                                      "r").read())
         device.connection_callback(True)
         device.state_data_available()
         device.sensor_data_available()
@@ -517,8 +590,11 @@ class TestLibPureCoolLink(unittest.TestCase):
         device.set_configuration(sleep_timer=10)
         self.assertEqual(mocked_publish.call_count, 3)
         self.assertEqual(device.__repr__(),
-                         "DysonDevice(device-id-1,True,device-1,21.03.08,True"
-                         ",False,475,NetworkDevice(device-1,host,1111))")
+                         "DysonDevice(serial=device-id-1,active=True,"
+                         "name=device-1,version=21.03.08,auto_update=True,"
+                         "new_version_available=False,product_type=475,"
+                         "network_device=NetworkDevice(name=device-1,"
+                         "address=host,port=1111))")
         device.disconnect()
 
     @mock.patch('paho.mqtt.client.Client.publish',
@@ -539,8 +615,8 @@ class TestLibPureCoolLink(unittest.TestCase):
         })
         network_device = NetworkDevice('device-1', 'host', 1111)
         device._add_network_device(network_device)
-        device._current_state = DysonState(open("tests/data/state.json", "r").
-                                           read())
+        device._current_state = DysonState(Desk, open("tests/data/state.json",
+                                                      "r").read())
         device.connection_callback(True)
         device.state_data_available()
         device.sensor_data_available()
@@ -550,8 +626,11 @@ class TestLibPureCoolLink(unittest.TestCase):
         device.set_configuration(sleep_timer=0)
         self.assertEqual(mocked_publish.call_count, 3)
         self.assertEqual(device.__repr__(),
-                         "DysonDevice(device-id-1,True,device-1,21.03.08,True"
-                         ",False,475,NetworkDevice(device-1,host,1111))")
+                         "DysonDevice(serial=device-id-1,active=True,"
+                         "name=device-1,version=21.03.08,auto_update=True,"
+                         "new_version_available=False,product_type=475,"
+                         "network_device=NetworkDevice(name=device-1,"
+                         "address=host,port=1111))")
         device.disconnect()
 
     @mock.patch('paho.mqtt.client.Client.publish',
@@ -573,8 +652,8 @@ class TestLibPureCoolLink(unittest.TestCase):
         })
         network_device = NetworkDevice('device-1', 'host', 1111)
         device._add_network_device(network_device)
-        device._current_state = DysonState(open("tests/data/state.json", "r").
-                                           read())
+        device._current_state = DysonState(Desk, open("tests/data/state.json",
+                                                      "r").read())
         device.connection_callback(False)
         connected = device.connect(None)
         self.assertFalse(connected)
@@ -585,8 +664,11 @@ class TestLibPureCoolLink(unittest.TestCase):
                                  night_mode=NightMode.NIGHT_MODE_OFF)
         self.assertEqual(mocked_publish.call_count, 0)
         self.assertEqual(device.__repr__(),
-                         "DysonDevice(device-id-1,True,device-1,21.03.08,True"
-                         ",False,475,NetworkDevice(device-1,host,1111))")
+                         "DysonDevice(serial=device-id-1,active=True,"
+                         "name=device-1,version=21.03.08,auto_update=True,"
+                         "new_version_available=False,product_type=475,"
+                         "network_device=NetworkDevice(name=device-1,"
+                         "address=host,port=1111))")
 
     def test_network_device(self):
         device = NetworkDevice("device", "192.168.1.1", "8090")
@@ -594,10 +676,12 @@ class TestLibPureCoolLink(unittest.TestCase):
         self.assertEqual(device.address, "192.168.1.1")
         self.assertEqual(device.port, "8090")
         self.assertEqual(device.__repr__(),
-                         "NetworkDevice(device,192.168.1.1,8090)")
+                         "NetworkDevice(name=device,address=192.168.1.1,"
+                         "port=8090)")
 
     def test_dyson_state(self):
-        dyson_state = DysonState(open("tests/data/state.json", "r").read())
+        dyson_state = DysonState(Desk,
+                                 open("tests/data/state.json", "r").read())
         self.assertEqual(dyson_state.fan_mode, FanMode.AUTO.value)
         self.assertEqual(dyson_state.fan_state, FanState.FAN_ON.value)
         self.assertEqual(dyson_state.night_mode, NightMode.NIGHT_MODE_ON.value)
@@ -606,7 +690,36 @@ class TestLibPureCoolLink(unittest.TestCase):
                          Oscillation.OSCILLATION_OFF.value)
         self.assertEqual(dyson_state.filter_life, '2087')
         self.assertEqual(dyson_state.__repr__(),
-                         "DysonState(AUTO,FAN,ON,AUTO,OFF,2087,0004,ON)")
+                         "DysonState(fan_mode=AUTO,fan_state=FAN,"
+                         "night_mode=ON,speed=AUTO,oscillation=OFF,"
+                         "filter_life=2087,quality_target=0004,"
+                         "standby_monitoring=ON)")
+        self.assertEqual(dyson_state.quality_target,
+                         QualityTarget.QUALITY_NORMAL.value)
+        self.assertEqual(dyson_state.standby_monitoring,
+                         SM.STANDBY_MONITORING_ON.value)
+
+    def test_dyson_state_hot(self):
+        dyson_state = DysonState(Hot,
+                                 open("tests/data/state_hot.json", "r").read())
+        self.assertEqual(dyson_state.fan_mode, FanMode.AUTO.value)
+        self.assertEqual(dyson_state.fan_state, FanState.FAN_ON.value)
+        self.assertEqual(dyson_state.night_mode, NightMode.NIGHT_MODE_ON.value)
+        self.assertEqual(dyson_state.speed, FanSpeed.FAN_SPEED_AUTO.value)
+        self.assertEqual(dyson_state.oscillation,
+                         Oscillation.OSCILLATION_OFF.value)
+        self.assertEqual(dyson_state.filter_life, '2087')
+        self.assertEqual(dyson_state.heat_state, 'heat')
+        self.assertEqual(dyson_state.tilt, 'Value')
+        self.assertEqual(dyson_state.focus_mode, 'spread')
+        self.assertEqual(dyson_state.heat_mode, 'on')
+        self.assertEqual(dyson_state.heat_target, '295')
+        self.assertEqual(dyson_state.__repr__(),
+                         "DysonState(fan_mode=AUTO,fan_state=FAN,"
+                         "night_mode=ON,speed=AUTO,oscillation=OFF,"
+                         "filter_life=2087,quality_target=0004,"
+                         "standby_monitoring=ON,tilt=Value,focus_mode=spread,"
+                         "heat_mode=on,heat_target=295,heat_state=heat)")
         self.assertEqual(dyson_state.quality_target,
                          QualityTarget.QUALITY_NORMAL.value)
         self.assertEqual(dyson_state.standby_monitoring,
@@ -629,3 +742,29 @@ class TestLibPureCoolLink(unittest.TestCase):
         self.assertEqual(sensor_state.humidity, 54)
         self.assertEqual(sensor_state.temperature, 296.7)
         self.assertEqual(sensor_state.volatil_organic_compounds, 5)
+
+    def test_heat_target_celsius(self):
+        self.assertEqual(HeatTarget.celsius(25), "2980")
+
+        with self.assertRaises(DysonInvalidTargetTemperatureException) as ex:
+            HeatTarget.celsius(38)
+        invalid_target_exception = ex.exception
+        self.assertEqual(invalid_target_exception.temperature_unit,
+                         DysonInvalidTargetTemperatureException.CELSIUS)
+        self.assertEqual(invalid_target_exception.current_value, 38)
+        self.assertEqual(invalid_target_exception.__repr__(),
+                         "38 is not a valid temperature target. "
+                         "It must be between 1 to 37 inclusive.")
+
+    def test_heat_target_fahrenheit(self):
+        self.assertEqual(HeatTarget.fahrenheit(77), "2980")
+
+        with self.assertRaises(DysonInvalidTargetTemperatureException) as ex:
+            HeatTarget.fahrenheit(99)
+        invalid_target_exception = ex.exception
+        self.assertEqual(invalid_target_exception.temperature_unit,
+                         DysonInvalidTargetTemperatureException.FAHRENHEIT)
+        self.assertEqual(invalid_target_exception.current_value, 99)
+        self.assertEqual(invalid_target_exception.__repr__(),
+                         "99 is not a valid temperature target. "
+                         "It must be between 34 to 98 inclusive.")

--- a/tests/test_libpurecoollink.py
+++ b/tests/test_libpurecoollink.py
@@ -10,7 +10,7 @@ from libpurecoollink.dyson import DysonAccount, NetworkDevice, \
 from libpurecoollink.const import FanMode, NightMode, FanSpeed, Oscillation, \
     FanState, QualityTarget, StandbyMonitoring as SM, \
     DYSON_PURE_COOL_LINK_DESK as Desk, DYSON_PURE_HOT_COOL_LINK_TOUR as Hot, \
-    HeatMode, HeatTarget, FocusMode
+    HeatMode, HeatState, HeatTarget, FocusMode, TiltState
 from libpurecoollink.exceptions import DysonInvalidTargetTemperatureException
 
 
@@ -709,17 +709,17 @@ class TestLibPureCoolLink(unittest.TestCase):
         self.assertEqual(dyson_state.oscillation,
                          Oscillation.OSCILLATION_OFF.value)
         self.assertEqual(dyson_state.filter_life, '2087')
-        self.assertEqual(dyson_state.heat_state, 'heat')
-        self.assertEqual(dyson_state.tilt, 'Value')
-        self.assertEqual(dyson_state.focus_mode, 'spread')
-        self.assertEqual(dyson_state.heat_mode, 'on')
-        self.assertEqual(dyson_state.heat_target, '295')
+        self.assertEqual(dyson_state.heat_mode, HeatMode.HEAT_ON.value)
+        self.assertEqual(dyson_state.heat_state, HeatState.HEAT_STATE_ON.value)
+        self.assertEqual(dyson_state.tilt, TiltState.TILT_FALSE.value)
+        self.assertEqual(dyson_state.focus_mode, FocusMode.FOCUS_OFF.value)
+        self.assertEqual(dyson_state.heat_target, '2950')
         self.assertEqual(dyson_state.__repr__(),
                          "DysonState(fan_mode=AUTO,fan_state=FAN,"
                          "night_mode=ON,speed=AUTO,oscillation=OFF,"
                          "filter_life=2087,quality_target=0004,"
-                         "standby_monitoring=ON,tilt=Value,focus_mode=spread,"
-                         "heat_mode=on,heat_target=295,heat_state=heat)")
+                         "standby_monitoring=ON,tilt=OK,focus_mode=OFF,"
+                         "heat_mode=HEAT,heat_target=2950,heat_state=HEAT)")
         self.assertEqual(dyson_state.quality_target,
                          QualityTarget.QUALITY_NORMAL.value)
         self.assertEqual(dyson_state.standby_monitoring,


### PR DESCRIPTION
Including turning heat mode on/off, setting the target temperature,
and set the stream of wind focus or wide spread.

Also fixed several issues in sensor returning string "OFF" but the original code
casting it to int, which causes exception thrown. Added checking for it.


This was tested in a pure hot plus cool link ONLY. Not sure if the added functionality and messages will affect the communication with pure cool link or not. It might be better to separate the two devices in the future.