### PR TITLE
add support for dyson.cn devices

### DIFF
--- a/libpurecoollink/dyson.py
+++ b/libpurecoollink/dyson.py
@@ -32,6 +32,9 @@ class DysonAccount:
         self._country = country
         self._logged = False
         self._auth = None
+        self._api = DYSON_API_URL
+        if self._country == 'CN':
+            self._api = "api.cp.dyson.cn"
 
     def login(self):
         """Login to dyson web services."""
@@ -41,7 +44,7 @@ class DysonAccount:
         }
         login = requests.post(
             "https://{0}/v1/userregistration/authenticate?country={1}".format(
-                DYSON_API_URL, self._country), request_body, verify=False)
+                self._api, self._country), request_body, verify=False)
         # pylint: disable=no-member
         if login.status_code == requests.codes.ok:
             json_response = login.json()
@@ -57,7 +60,7 @@ class DysonAccount:
         if self._logged:
             device_response = requests.get(
                 "https://{0}/v1/provisioningservice/manifest".format(
-                    DYSON_API_URL), verify=False, auth=self._auth)
+                    self._api), verify=False, auth=self._auth)
             devices = []
             for device in device_response.json():
                 if is_360_eye_device(device):


### PR DESCRIPTION
Hi, dyson has chosen another domain instead of language code in url params for Chinese customers. So I submitted this PR to add support for `api.cp.dyson.cn` domain when language code is CN. I'm not quite familiar with python, so I wonder whether my modification is suitable and I'm not sure how to add a proper test case for it. But I had tested manually with my own Pure Hot Cool Link device bought in China. It works well as expected. Thanks.