### PR TITLE
update url

### DIFF
--- a/libpurecoollink/dyson.py
+++ b/libpurecoollink/dyson.py
@@ -14,7 +14,7 @@ from .exceptions import DysonNotLoggedException
 
 _LOGGER = logging.getLogger(__name__)
 
-DYSON_API_URL = "api.cp.dyson.com"
+DYSON_API_URL = "appapi.cp.dyson.com"
 
 
 class DysonAccount:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ PROJECT_CLASSIFIERS = [
 
 setup(
     name="libpurecoollink",
-    version="0.4.2",
+    version="0.4.3",
     license="Apache License 2.0",
     url="http://libpurecoollink.readthedocs.io",
     download_url="https://github.com/CharlesBlonde/libpurecoollink",


### PR DESCRIPTION
Constant failures on existing URL (401s mostly). I set up Charles on my phone to see if it changed, saw traffic to `appapi.cp.dyson.com` but not `api.cp.dyson.com`. Everything worked smoothly when I updated. 

Great library!